### PR TITLE
Add r2commodore

### DIFF
--- a/db/r2commodore
+++ b/db/r2commodore
@@ -1,0 +1,16 @@
+name: r2commodore
+type: git
+repo: https://github.com/thestr4ng3r/r2commodore
+desc: "[asm] CBM Basic Support (C64, VIC-20, PET, ...)"
+
+install: 
+  - mkdir build
+  - pwd
+  - cmake -B build -S . -DCMAKE_INSTALL_PREFIX=~/.local
+  - make -C build -j4
+  - make -C build install
+
+uninstall:
+  - true
+# Doesn't work:  - cat build/install-manifest.txt | xargs rm -v
+


### PR DESCRIPTION
The `cat build/install-manifest.txt | xargs rm -v` will not work unless the commands will be executed in a shell. I have no idea how to do it with the current r2pm state. Do you maybe have an idea, @qbarrand?

It's kind of surprising that the `~` expansion actually works, I am not sure at which point exactly it is expanded.

By the way it is quite tedious that the working directory can't be changed by `cd` because every next command will be run on its own from the root. `cd somewhere && do something` doesn't work as well because again there is no shell.

This kind of brings me back to https://github.com/radareorg/r2pm/issues/47
cc @XVilka @radare @xarkes 